### PR TITLE
feat: adicionar DTOs e controller para ações sustentáveis

### DIFF
--- a/src/main/java/APISustentavel/Controller/AcaoSustentavelController.java
+++ b/src/main/java/APISustentavel/Controller/AcaoSustentavelController.java
@@ -1,0 +1,11 @@
+package APISustentavel.Controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/acoesSustentaveis")
+public class AcaoSustentavelController {
+
+
+}

--- a/src/main/java/APISustentavel/Model/Dtos/RequestAcaoSustentavelDTO.java
+++ b/src/main/java/APISustentavel/Model/Dtos/RequestAcaoSustentavelDTO.java
@@ -1,0 +1,37 @@
+package APISustentavel.Model.Dtos;
+
+import APISustentavel.Model.Enum.CategoriaEnum;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestAcaoSustentavelDTO {
+
+    @NotBlank(message = "O título não pode estar vazio ou conter apenas espaços em branco.")
+    @Size(min = 3, max = 100, message = "O título deve ter entre 3 a 100 caracteres.")
+    private String titulo;
+
+    @NotBlank(message = "A descrição  não pode estar vazia ou conter apenas espaços em branco.")
+    @Size(min = 50, max = 1000, message = "A descrição deve ter entre 50 a 1000 caracteres.")
+    private String descricao;
+
+    @NotNull(message = "A categoria não pode estar nula.")
+    private CategoriaEnum categoria;
+
+    @NotNull(message = "A data de realização não pode estar nula.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @FutureOrPresent(message = "A data de realização deve estar no presente ou no futuro.")
+    private LocalDate dataRealizacao;
+
+    @NotBlank(message = "O nome do responsável não pode estar vazio ou conter apenas espaços em branco.")
+    @Size(min = 3, max = 20, message = "O nome do responsável deve ter entre 3 a 20 caracteres.")
+    private String responsavel;
+
+}

--- a/src/main/java/APISustentavel/Model/Dtos/ResponseAcaoSustentavelDTO.java
+++ b/src/main/java/APISustentavel/Model/Dtos/ResponseAcaoSustentavelDTO.java
@@ -1,0 +1,21 @@
+package APISustentavel.Model.Dtos;
+
+import APISustentavel.Model.Enum.CategoriaEnum;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseAcaoSustentavelDTO {
+
+    private Long id;
+    private String titulo;
+    private String descricao;
+    private CategoriaEnum categoria;
+    private LocalDate dataRealizacao;
+    private String responsavel;
+}

--- a/src/main/java/APISustentavel/Model/Entity/AcaoSustentavel.java
+++ b/src/main/java/APISustentavel/Model/Entity/AcaoSustentavel.java
@@ -1,0 +1,32 @@
+package APISustentavel.Model.Entity;
+
+import APISustentavel.Model.Enum.CategoriaEnum;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "acaoSustentavel")
+public class AcaoSustentavel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String titulo;
+    @Column(length = 1000)
+    private String descricao;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CategoriaEnum categoria;
+    @Column(nullable = false)
+    private LocalDate dataRealizacao;
+    @Column(nullable = false)
+    private String responsavel;
+}

--- a/src/main/java/APISustentavel/Model/Enum/CategoriaEnum.java
+++ b/src/main/java/APISustentavel/Model/Enum/CategoriaEnum.java
@@ -1,0 +1,9 @@
+package APISustentavel.Model.Enum;
+
+public enum CategoriaEnum {
+    DOACAO,
+    RECICLAGEM,
+    PLANTIO,
+    EDUCACAO_AMBIENTAL,
+    OUTROS;
+}

--- a/src/main/java/APISustentavel/Repository/AcaoSustentavelRepository.java
+++ b/src/main/java/APISustentavel/Repository/AcaoSustentavelRepository.java
@@ -1,0 +1,9 @@
+package APISustentavel.Repository;
+
+import APISustentavel.Model.Entity.AcaoSustentavel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AcaoSustentavelRepository extends JpaRepository<AcaoSustentavel, Long> {
+}


### PR DESCRIPTION
Este PR adiciona a estrutura inicial da API para ações sustentáveis:

- RequestAcaoSustentavelDTO com validações de entrada (Bean Validation)
- ResponseAcaoSustentavelDTO para retorno das ações
- AcaoSustentavelController com endpoint base (/acoesSustentaveis) preparado para CRUD

Objetivo: preparar a base para cadastro, consulta e atualização de ações sustentáveis.