### PR TITLE
feat: implementar CRUD completo para ações sustentáveis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>3.2.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/APISustentavel/Configuration/ModelMapperConfig.java
+++ b/src/main/java/APISustentavel/Configuration/ModelMapperConfig.java
@@ -1,0 +1,14 @@
+package APISustentavel.Configuration;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/APISustentavel/Controller/AcaoSustentavelController.java
+++ b/src/main/java/APISustentavel/Controller/AcaoSustentavelController.java
@@ -1,11 +1,67 @@
 package APISustentavel.Controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import APISustentavel.Model.Dtos.RequestAcaoSustentavelDTO;
+import APISustentavel.Model.Dtos.ResponseAcaoSustentavelDTO;
+import APISustentavel.Model.Entity.AcaoSustentavel;
+import APISustentavel.Service.AcaoSustentavelService;
+import jakarta.validation.Valid;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/acoesSustentaveis")
+@RequestMapping("/acoes")
 public class AcaoSustentavelController {
 
+    @Autowired
+    private AcaoSustentavelService acaoSustentavelService;
 
+    @Autowired
+    private ModelMapper modelMapper;
+
+    @GetMapping
+    public ResponseEntity<List<ResponseAcaoSustentavelDTO>> list(){
+        List<ResponseAcaoSustentavelDTO> acoesSustentaveis = this.acaoSustentavelService.findAllAcoesSustentaveis().stream()
+                .map(acaoSustentavel -> modelMapper.map(acaoSustentavel, ResponseAcaoSustentavelDTO.class)).collect(Collectors.toList());
+
+        return acoesSustentaveis.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(acoesSustentaveis);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ResponseAcaoSustentavelDTO> getById(@PathVariable Long id){
+        AcaoSustentavel acaoSustentavel = acaoSustentavelService.findAcaoSustentavelById(id);
+        ResponseAcaoSustentavelDTO acaoSustentavelDTO = modelMapper.map(acaoSustentavel, ResponseAcaoSustentavelDTO.class);
+
+        return ResponseEntity.ok(acaoSustentavelDTO);
+    }
+
+    @PostMapping
+    public ResponseEntity<ResponseAcaoSustentavelDTO> create(@RequestBody @Valid RequestAcaoSustentavelDTO acaoSustentavelDTO) throws Exception{
+        AcaoSustentavel acaoSustentavel = modelMapper.map(acaoSustentavelDTO, AcaoSustentavel.class);
+        AcaoSustentavel createdAcaoSustentavel = acaoSustentavelService.create(acaoSustentavel);
+        ResponseAcaoSustentavelDTO createdAcaoSustentavelDTO = modelMapper.map(createdAcaoSustentavel, ResponseAcaoSustentavelDTO.class);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdAcaoSustentavelDTO);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ResponseAcaoSustentavelDTO> update(@PathVariable Long id, @RequestBody RequestAcaoSustentavelDTO acaoSustentavelDTO) throws Exception{
+        AcaoSustentavel acaoSustentavel = modelMapper.map(acaoSustentavelDTO, AcaoSustentavel.class);
+        AcaoSustentavel acaoSustentavelUpdate = this.acaoSustentavelService.update(id, acaoSustentavel);
+        ResponseAcaoSustentavelDTO acaoSustentavelUpdateDTO = modelMapper.map(acaoSustentavelUpdate, ResponseAcaoSustentavelDTO.class);
+
+        return ResponseEntity.ok(acaoSustentavelUpdateDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> delete(@PathVariable Long id) {
+        this.acaoSustentavelService.delete(id);
+
+        return ResponseEntity.ok("A ação sustentável foi deletada com sucesso.");
+    }
 }

--- a/src/main/java/APISustentavel/Service/AcaoSustentavelService.java
+++ b/src/main/java/APISustentavel/Service/AcaoSustentavelService.java
@@ -1,0 +1,44 @@
+package APISustentavel.Service;
+
+import APISustentavel.Model.Entity.AcaoSustentavel;
+import APISustentavel.Repository.AcaoSustentavelRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AcaoSustentavelService {
+
+    @Autowired
+    AcaoSustentavelRepository acaoSustentavelRepository;
+
+    public List<AcaoSustentavel> findAllAcoesSustentaveis(){
+        return acaoSustentavelRepository.findAll();
+    }
+
+    public AcaoSustentavel findAcaoSustentavelById(Long id){
+        return acaoSustentavelRepository.findById(id).orElseThrow(
+                () -> new RuntimeException("")
+        );
+    }
+
+    public AcaoSustentavel create(AcaoSustentavel acaoSustentavel){
+        return acaoSustentavelRepository.save(acaoSustentavel);
+    }
+
+    public AcaoSustentavel update(Long id, AcaoSustentavel acaoSustentavelUpdate) {
+        AcaoSustentavel existingAcaoSustentavel = findAcaoSustentavelById(id);
+        existingAcaoSustentavel.setTitulo(acaoSustentavelUpdate.getTitulo());
+        existingAcaoSustentavel.setDescricao(acaoSustentavelUpdate.getDescricao());
+        existingAcaoSustentavel.setCategoria(acaoSustentavelUpdate.getCategoria());
+        existingAcaoSustentavel.setDataRealizacao(acaoSustentavelUpdate.getDataRealizacao());
+        existingAcaoSustentavel.setResponsavel(acaoSustentavelUpdate.getResponsavel());
+        return acaoSustentavelRepository.save(existingAcaoSustentavel);
+    }
+
+    public void delete(Long id){
+        AcaoSustentavel acaoSustentavel = findAcaoSustentavelById(id);
+        acaoSustentavelRepository.delete(acaoSustentavel);
+    }
+}


### PR DESCRIPTION
Este PR implementa o CRUD completo da entidade `AcaoSustentavel` com boas práticas de arquitetura e uso de DTOs.

### Alterações principais
- feat(service): criar `AcaoSustentavelService` com operações CRUD
- chore(deps): adicionar dependência do ModelMapper no `pom.xml`
- feat(config): adicionar configuração global do ModelMapper
- feat(controller): criar `AcaoSustentavelController` com endpoints REST
  - GET /acoes → listar todas as ações
  - GET /acoes/{id} → buscar ação por ID
  - POST /acoes → cadastrar nova ação
  - PUT /acoes/{id} → atualizar ação
  - DELETE /acoes/{id} → excluir ação
